### PR TITLE
do not run github actions if only markdown changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,11 @@
 name: CI
 'on':
   pull_request:
+    paths-ignore:
+      - '*.md' # Markdown docs need no linting/testing etc.
   push:
+    paths-ignore:
+      - '*.md'
     branches:
       - master
   schedule:


### PR DESCRIPTION
why:
* these docs only changes don't need to be tested
* running CI takes over 10 minutes, so this shaves that off